### PR TITLE
Reintroduce `.connected` attrubute

### DIFF
--- a/sun2000_modbus/inverter.py
+++ b/sun2000_modbus/inverter.py
@@ -37,6 +37,10 @@ class Sun2000:
         """Check if underlying tcp socket is open"""
         return self.inverter.is_socket_open()
 
+    @property
+    def connected(self):
+        return self.isConnected()
+
     def read_raw_value(self, register):
         if not self.isConnected():
             raise ValueError('Inverter is not connected')


### PR DESCRIPTION
This is a proposal to reintroduce the `.connected` attribute. Its suppression in recent versions of the module causes errors in programs using earlier versions. In this proposal, an equivalent is reintroduced, now as a property, relying directly on the new `.isConnected()` method.