### PR TITLE
Implement sun2000_modbus.inverter own logger

### DIFF
--- a/sun2000_modbus/inverter.py
+++ b/sun2000_modbus/inverter.py
@@ -6,7 +6,12 @@ from pymodbus.exceptions import ModbusIOException, ConnectionException
 
 from . import datatypes
 
-logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+log_format = logging.Formatter('%(levelname)s:%(name)s:%(message)s')
+handler = logging.StreamHandler()
+handler.setFormatter(log_format)
+logger.addHandler(handler)
 
 
 class Sun2000:
@@ -20,10 +25,10 @@ class Sun2000:
             self.inverter.connect()
             time.sleep(self.wait)
             if self.isConnected():
-                logging.info('Successfully connected to inverter')
+                logger.info('Successfully connected to inverter')
                 return True
             else:
-                logging.error('Connection to inverter failed')
+                logger.error('Connection to inverter failed')
                 return False
 
     def disconnect(self):
@@ -48,10 +53,10 @@ class Sun2000:
         try:
             register_value = self.inverter.read_holding_registers(register.value.address, register.value.quantity, unit=self.unit)
             if type(register_value) == ModbusIOException:
-                logging.error("Inverter unit did not respond")
+                logger.error("Inverter unit did not respond")
                 raise register_value
         except ConnectionException:
-            logging.error("A connection error occurred")
+            logger.error("A connection error occurred")
             raise
 
         return datatypes.decode(register_value.encode()[1:], register.value.data_type)
@@ -90,10 +95,10 @@ class Sun2000:
         try:
             register_range_value = self.inverter.read_holding_registers(start_address, quantity, unit=self.unit)
             if type(register_range_value) == ModbusIOException:
-                logging.error("Inverter unit did not respond")
+                logger.error("Inverter unit did not respond")
                 raise register_range_value
         except ConnectionException:
-            logging.error("A connection error occurred")
+            logger.error("A connection error occurred")
             raise
 
         return datatypes.decode(register_range_value.encode()[1:], datatypes.DataType.MULTIDATA)


### PR DESCRIPTION
This proposal implements an own logger for the `sun2000_modbus.inverter` module.  Before, it was using the default "root" logger. If a program using the module needed to mute its log messages, the only option was to mute the "root" logger, which also muted messages from all other loggers. A module-specific logger can be tuned without impact on other loggers. It also clearly identifies the origin of the messages as "sun2000_modbus.inverter" instead of "root".

Usage examples (in a custom program):
1°) catch the logger
    `inv_log = logging.getLogger("sun2000_modbus.inverter")`
2°) use one of the following instructions
    `inv_log.setLevel(logging.INFO)  # original behaviour`
    `inv_log.setLevel(logging.ERROR)  # or any other level`
    `inv_log.disabled = True  # disables this logger only`